### PR TITLE
Remove {} from string indexes and replace with []

### DIFF
--- a/app/Controllers/ActionBase.php
+++ b/app/Controllers/ActionBase.php
@@ -10,7 +10,7 @@ abstract class ActionBase
         foreach ($data as $field => $value) {
             if (array_key_exists($field, $modelFields)) {
                 $dataType = $modelFields[$field];
-                if ($dataType{0} === '*') {
+                if ($dataType[0] === '*') {
                     unset($data[$field]);
                 }
             }

--- a/app/Controllers/QueryActionBase.php
+++ b/app/Controllers/QueryActionBase.php
@@ -27,12 +27,12 @@ abstract class QueryActionBase extends ActionBase
     protected $allowAll = false;
 
     /**
-     * @var array Set to an array of column names and directions ['column_name1' => 'asc', 'column_name2' => 'desc']
+     * @var array<string> Set to an array of column names and directions ['column_name1' => 'asc', 'column_name2' => 'desc']
      */
     protected $orderBy = [];
 
     /**
-     * @var array Set to an array of column names to group by
+     * @var array<string> Set to an array of column names to group by
      */
     protected $groupBy = [];
 
@@ -89,7 +89,7 @@ abstract class QueryActionBase extends ActionBase
             {
                 $model = $this->model;
                 foreach ($parsedRequest as $item => $fieldValue) {
-                    if ($item{0} === '_') {
+                    if ($item[0] === '_') {
                         $columnName = substr($item, 1);
                         $model = $model->where($columnName, '=', $fieldValue);
                     }

--- a/app/Controllers/QueryValidatorBase.php
+++ b/app/Controllers/QueryValidatorBase.php
@@ -34,7 +34,7 @@ abstract class QueryValidatorBase
             case '_':
                 $columnCount = 0;
                 foreach ($parsedRequest as $item => $value) {
-                    if ($item{0} === '_') {
+                    if ($item[0] === '_') {
                         $columnName = substr($item, 1);
                         if (!array_key_exists($columnName, $this->modelFields)) {
                             $responseBody->registerParam('invalid', $columnName, null);

--- a/app/Robo/Plugin/Commands/Templates/WriteValidatorTemplate.php
+++ b/app/Robo/Plugin/Commands/Templates/WriteValidatorTemplate.php
@@ -23,7 +23,7 @@ class TableAliasWriteValidator extends WriteValidatorBase
             // Is the model field NOT in the request?
             if (!V::key($field)->validate($parsedRequest)) {
                 // Any dataType proceeded with an * are protected fields and can not be changed (e.g. password_hash)
-                if ($dataType{0} === '*') {
+                if ($dataType[0] === '*') {
                     continue;
                 }
 
@@ -31,7 +31,7 @@ class TableAliasWriteValidator extends WriteValidatorBase
                 $responseBody->registerParam('optional', $field, $dataType);
             } else {
                 // If Datatype is proceeded with an * it means the field is protected and can not be changed (e.g. password_hash)
-                if ($dataType{1} === '*') {
+                if ($dataType[1] === '*') {
                     $responseBody->registerParam('invalid', $field, null);
                 }
             }


### PR DESCRIPTION
string index {} are being deprecated.

```
$string = "test";
$lastChar = $string[-1];
$lastChar = $string{-1}; // Deprecated.